### PR TITLE
Fix panic on despawn

### DIFF
--- a/crates/bevy_121/examples/simple.rs
+++ b/crates/bevy_121/examples/simple.rs
@@ -12,6 +12,9 @@ fn main() {
     // Alice is in over her head, have Cart take over
     world.entity_mut(cart).insert(Assignment(bsn));
     assert_eq!(world.entity(bsn).get::<Assignee>().unwrap().0, cart);
+    // Cart finished the assignment, time to clean up.
+    world.despawn(bsn);
+    assert!(world.entity(cart).get::<Assignment>().is_none());
 }
 
 #[derive(AsymmetricOneToOne)]


### PR DESCRIPTION
When despawning:
1. `on_replace` of the despawning entity runs.
2. The entity despawns.
3. `on_replace` of the target runs. <-- This panics because the referenced entity no longer exists.